### PR TITLE
Add splitTableBeforeRow to split long tables

### DIFF
--- a/js/tinymce/plugins/table/classes/Plugin.js
+++ b/js/tinymce/plugins/table/classes/Plugin.js
@@ -249,6 +249,7 @@ define("tinymce/tableplugin/Plugin", [
 			menu: [
 				{text: 'Insert row before', onclick: cmd('mceTableInsertRowBefore'), onPostRender: postRenderCell},
 				{text: 'Insert row after', onclick: cmd('mceTableInsertRowAfter'), onPostRender: postRenderCell},
+				{text: 'Start new table', onclick: cmd('mceTableSplitTableBeforeRow'), onPostRender: postRenderCell},
 				{text: 'Delete row', onclick: cmd('mceTableDeleteRow'), onPostRender: postRenderCell},
 				{text: 'Row properties', onclick: cmd('mceTableRowProps'), onPostRender: postRenderCell},
 				{text: '-'},
@@ -340,6 +341,10 @@ define("tinymce/tableplugin/Plugin", [
 
 			mceTableInsertRowAfter: function(grid) {
 				grid.insertRow();
+			},
+
+			mceTableSplitTableBeforeRow: function(grid) {
+				grid.splitTableBeforeRow();
 			},
 
 			mceTableInsertColBefore: function(grid) {

--- a/tests/plugins/table.js
+++ b/tests/plugins/table.js
@@ -527,6 +527,13 @@
 		);
 	});
 
+	test("mceTableSplitTableBeforeRow command", function() {
+		editor.setContent('<table><thead><tr><td>1</td><td>2</td></tr></thead><tbody><tr><td rowspan="2">3</td><td>4</td></tr><tr><td>5</td></tr></tbody></table>');
+		Utils.setSelection('tbody tr:nth-child(2)', 0);
+		editor.execCommand('mceTableSplitTableBeforeRow');
+		equal(cleanTableHtml(editor.getContent()), '<table><thead><tr><td>1</td><td>2</td></tr></thead><tbody><tr><td>3</td><td>4</td></tr></tbody></table><p>&nbsp;</p><table><thead><tr><td>1</td><td>2</td></tr></thead><tbody><tr><td>3</td><td>5</td></tr></tbody></table>');
+	});
+
 	test("Tab key navigation", function() {
 		editor.setContent('<table><tbody><tr><td>A1</td><td>A2</td></tr><tr><td>B1</td><td>B2</td></tr></tbody></table><p>x</p>');
 


### PR DESCRIPTION
Add splitTableBeforeRow to table plugin to allow users to split a long
table at a specific row.
